### PR TITLE
Made connecting of nodes interruptible 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /GraphExample/GraphExample.csproj.user
 /Graph/bin/Debug/Graph.dll
 /Graph/bin/Debug/Graph.pdb
+/Graph/obj
 /Graph/obj/Debug/DesignTimeResolveAssemblyReferencesInput.cache
 /Graph/obj/Debug/Graph.csproj.FileListAbsolute.txt
 /Graph/obj/Debug/Graph.dll

--- a/Graph/Graph.csproj
+++ b/Graph/Graph.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Items\NodeNumericSliderItem.cs" />
     <Compile Include="NodeSelection.cs" />
     <Compile Include="Items\NodeDropDownItem.cs" />
     <Compile Include="SelectionForm.cs">

--- a/Graph/Items/NodeNumericSliderItem.cs
+++ b/Graph/Items/NodeNumericSliderItem.cs
@@ -1,5 +1,5 @@
 ﻿#region License
-// Copyright (c) 2009 Sander van Rossen
+// Copyright (c) 2009 Sander van Rossen, 2013 Oliver Salzburg
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Graph/Items/NodeNumericSliderItem.cs
+++ b/Graph/Items/NodeNumericSliderItem.cs
@@ -1,0 +1,205 @@
+﻿#region License
+// Copyright (c) 2009 Sander van Rossen
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace Graph.Items
+{
+	public sealed class NodeNumericSliderItem : NodeItem
+	{
+		public event EventHandler<NodeItemEventArgs> Clicked;
+		public event EventHandler<NodeItemEventArgs> ValueChanged;
+
+		public NodeNumericSliderItem(string text, float sliderSize, float textSize, float minValue, float maxValue, float defaultValue, bool inputEnabled, bool outputEnabled) :
+			base(inputEnabled, outputEnabled)
+		{
+			this.Text = text;
+			this.MinimumSliderSize = sliderSize;
+			this.TextSize = textSize;
+			this.MinValue = Math.Min(minValue, maxValue);
+			this.MaxValue = Math.Max(minValue, maxValue);
+			this.Value = defaultValue;
+		}
+
+		#region Text
+		string internalText = string.Empty;
+		public string Text
+		{
+			get { return internalText; }
+			set
+			{
+				if (internalText == value)
+					return;
+				internalText = value;
+				itemSize = Size.Empty;
+			}
+		}
+		#endregion
+
+		#region Dragging
+		internal bool Dragging { get; set; }
+		#endregion
+
+		public float MinimumSliderSize	{ get; set; }
+		public float TextSize			{ get; set; }
+
+		public float MinValue { get; set; }
+		public float MaxValue { get; set; }
+
+		float internalValue = 0.0f;
+		public float Value				
+		{
+			get { return internalValue; }
+			set
+			{
+				var newValue = value;
+				if (newValue < MinValue) newValue = MinValue;
+				if (newValue > MaxValue) newValue = MaxValue;
+				if (internalValue == newValue)
+					return;
+				internalValue = newValue;
+				if (ValueChanged != null)
+					ValueChanged(this, new NodeItemEventArgs(this));
+			}
+		}
+
+
+		public override bool OnClick()
+		{
+			base.OnClick();
+			if (Clicked != null)
+				Clicked(this, new NodeItemEventArgs(this));
+			return true;
+		}
+
+		public override bool OnStartDrag(PointF location, out PointF original_location) 
+		{
+			base.OnStartDrag(location, out original_location);
+			var size = (MaxValue - MinValue);
+			original_location.Y = location.Y;
+			original_location.X = ((Value / size) * sliderRect.Width) + sliderRect.Left;
+			Value = ((location.X - sliderRect.Left) / sliderRect.Width) * size;
+			Dragging = true; 
+			return true; 
+		}
+
+		public override bool OnDrag(PointF location) 
+		{
+			base.OnDrag(location);
+			var size = (MaxValue - MinValue);
+			Value = ((location.X - sliderRect.Left) / sliderRect.Width) * size;
+			return true; 
+		}
+
+		public override bool OnEndDrag() { base.OnEndDrag(); Dragging = false; return true; }
+
+
+		internal SizeF itemSize;
+		internal SizeF textSize;
+		internal RectangleF sliderRect;
+
+		
+		const int SliderBoxSize = 4;
+		const int SliderHeight	= 12;
+		const int Spacing		= 2;
+
+		internal override SizeF Measure(Graphics graphics)
+		{
+			if (!string.IsNullOrWhiteSpace(this.Text))
+			{
+				if (this.itemSize.IsEmpty)
+				{
+					var size = new Size(GraphConstants.MinimumItemWidth, GraphConstants.MinimumItemHeight);
+					var sliderWidth = this.MinimumSliderSize + SliderBoxSize;
+
+					this.textSize			= (SizeF)graphics.MeasureString(this.Text, SystemFonts.MenuFont, size, GraphConstants.LeftMeasureTextStringFormat);
+					this.textSize.Width		= Math.Max(this.TextSize, this.textSize.Width + 4);
+					this.itemSize.Width		= Math.Max(size.Width, this.textSize.Width + sliderWidth + Spacing);
+					this.itemSize.Height	= Math.Max(size.Height, this.textSize.Height);
+				}
+				return this.itemSize;
+			} else
+			{
+				return new SizeF(GraphConstants.MinimumItemWidth, GraphConstants.MinimumItemHeight);
+			}
+		}
+
+		internal override void Render(Graphics graphics, SizeF minimumSize, PointF location)
+		{
+			var size = Measure(graphics);
+			size.Width  = Math.Max(minimumSize.Width, size.Width);
+			size.Height = Math.Max(minimumSize.Height, size.Height);
+
+			var sliderOffset	= Spacing + this.textSize.Width;
+			var sliderWidth		= size.Width - sliderOffset	;
+
+			var textRect	= new RectangleF(location, size);
+			var sliderBox	= new RectangleF(location, size);
+			var sliderRect	= new RectangleF(location, size);
+			
+			// Calculate bounds for outer rectangle
+			sliderRect.X		= sliderRect.Right - sliderWidth;
+			sliderRect.Y		+= ((sliderRect.Bottom - sliderRect.Top) - SliderHeight) / 2.0f;
+			sliderRect.Width	= sliderWidth;
+			sliderRect.Height	= SliderHeight;
+			
+			textRect.Width -= sliderWidth + Spacing;
+
+			var valueSize		= (this.MaxValue - this.MinValue);
+			this.sliderRect		= sliderRect;
+			this.sliderRect.X	+= SliderBoxSize / 2.0f;
+
+			// Calculate bounds for inner rectangle
+			sliderBox.X			= sliderRect.X;
+			sliderBox.Y			= sliderRect.Y;
+			sliderBox.Width		= (this.Value * this.sliderRect.Width) / valueSize;
+			sliderBox.Height	= SliderHeight;
+
+			// Draw label
+			graphics.DrawString(this.Text, SystemFonts.MenuFont, Brushes.Black, textRect, GraphConstants.LeftTextStringFormat);
+			
+			// Draw inner rectangle
+			graphics.FillRectangle(Brushes.LightGray, sliderBox.X, sliderBox.Y, sliderBox.Width, sliderBox.Height);
+
+			// Draw outer rectangle
+			if ((state & (RenderState.Hover | RenderState.Dragging)) != 0)
+				graphics.DrawRectangle(Pens.White, sliderRect.X, sliderRect.Y, sliderRect.Width, sliderRect.Height);
+			else
+				graphics.DrawRectangle(Pens.Black, sliderRect.X, sliderRect.Y, sliderRect.Width, sliderRect.Height);
+
+			// Draw value marker into box
+			if ((state & (RenderState.Hover | RenderState.Dragging)) != 0)
+				graphics.DrawLine(Pens.White, sliderBox.X + sliderBox.Width, sliderBox.Y, sliderBox.X + sliderBox.Width, sliderBox.Y + sliderBox.Height);
+			else
+				graphics.DrawLine(Pens.Black, sliderBox.X + sliderBox.Width, sliderBox.Y, sliderBox.X + sliderBox.Width, sliderBox.Y + sliderBox.Height);
+
+			// Draw value
+			graphics.DrawString(this.Value.ToString(), SystemFonts.MenuFont, Brushes.Black, sliderRect, GraphConstants.LeftTextStringFormat);
+		}
+	}
+}


### PR DESCRIPTION
I needed an option to interrupt the possible connection of two node connectors.

I implemented this through a new event `ConnectionAdding`, which is fired whenever a connector is picked as a candidate for possible connection. The overlaying application can interrupt this connection through the `Cancel` property of the `EventArgs` passed with the event.

I also introduced a new `RenderState` flag for this (to signal a forbidden connection), don't know if I implemented that the right way.
