### PR TITLE
Made connecting of nodes interruptible 

### DIFF
--- a/Graph/GraphControl.cs
+++ b/Graph/GraphControl.cs
@@ -1,5 +1,5 @@
 ﻿#region License
-// Copyright (c) 2009 Sander van Rossen
+// Copyright (c) 2009 Sander van Rossen, 2013 Oliver Salzburg
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Graph/GraphRenderer.cs
+++ b/Graph/GraphRenderer.cs
@@ -480,6 +480,10 @@ namespace Graph
 			{
 				return Color.Black;
 			} else
+			if ((state & RenderState.Forbidden) != 0)
+			{
+				return Color.Red;
+			} else
 				return Color.LightGray;
 		}
 		

--- a/Graph/GraphRenderer.cs
+++ b/Graph/GraphRenderer.cs
@@ -1,5 +1,5 @@
 ﻿﻿#region License
-// Copyright (c) 2009 Sander van Rossen
+// Copyright (c) 2009 Sander van Rossen, 2013 Oliver Salzburg
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Graph/RenderState.cs
+++ b/Graph/RenderState.cs
@@ -1,5 +1,5 @@
 ﻿#region License
-// Copyright (c) 2009 Sander van Rossen
+// Copyright (c) 2009 Sander van Rossen, 2013 Oliver Salzburg
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Graph/RenderState.cs
+++ b/Graph/RenderState.cs
@@ -35,6 +35,7 @@ namespace Graph
 		Hover		= 2,
 		DraggedOver	= 4,
 		Dragging	= 8,
-		Focus		= 16
+		Focus		= 16,
+		Forbidden	= 32
 	}
 }


### PR DESCRIPTION
I needed an option to interrupt the possible connection of two node connectors.

I implemented this through a new event `ConnectionAdding`, which is fired whenever a connector is picked as a candidate for possible connection. The overlaying application can interrupt this connection through the `Cancel` property of the `EventArgs` passed with the event.

I also introduced a new `RenderState` flag for this (to signal a forbidden connection), don't know if I implemented that the right way.
