### PR TITLE
Compatibility highlight

### DIFF
--- a/Graph/Compatibility/AlwaysCompatible.cs
+++ b/Graph/Compatibility/AlwaysCompatible.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Graph.Compatibility {
+	/// <summary>
+	/// Will behave as if all node item connectors are compatible.
+	/// </summary>
+	public class AlwaysCompatible : ICompatibilityStrategy {
+		/// <summary>
+		/// Determine if two node item connectors could be connected to each other.
+		/// </summary>
+		/// <param name="from">From which node connector are we connecting.</param>
+		/// <param name="to">To which node connector are we connecting?</param>
+		/// <returns><see langword="true"/> if the connection is valid; <see langword="false"/> otherwise</returns>
+		public bool CanConnect( NodeConnector @from, NodeConnector to )
+		{
+			return true;
+		}
+	}
+}

--- a/Graph/Compatibility/ICompatibilityStrategy.cs
+++ b/Graph/Compatibility/ICompatibilityStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Graph.Compatibility {
+	/// <summary>
+	/// Describes a strategy to compare two node item connectors for a possible connection.
+	/// </summary>
+	public interface ICompatibilityStrategy {
+		/// <summary>
+		/// Determine if two node item connectors could be connected to each other.
+		/// </summary>
+		/// <param name="from">From which node connector are we connecting.</param>
+		/// <param name="to">To which node connector are we connecting?</param>
+		/// <returns><see langword="true"/> if the connection is valid; <see langword="false"/> otherwise</returns>
+		bool CanConnect(NodeConnector from, NodeConnector to);
+	}
+}

--- a/Graph/Compatibility/NeverCompatible.cs
+++ b/Graph/Compatibility/NeverCompatible.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Graph.Compatibility {
+	/// <summary>
+	/// Will behave as if all node item connectors aren't compatible.
+	/// </summary>
+	public class NeverCompatible : ICompatibilityStrategy {
+		/// <summary>
+		/// Determine if two node item connectors could be connected to each other.
+		/// </summary>
+		/// <param name="from">From which node connector are we connecting.</param>
+		/// <param name="to">To which node connector are we connecting?</param>
+		/// <returns><see langword="true"/> if the connection is valid; <see langword="false"/> otherwise</returns>
+		public bool CanConnect( NodeConnector @from, NodeConnector to )
+		{
+			return false;
+		}
+	}
+}

--- a/Graph/Compatibility/TagTypeCompatibility.cs
+++ b/Graph/Compatibility/TagTypeCompatibility.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Graph.Compatibility {
+	/// <summary>
+	/// Determines the compatibility between two node item connectors based on the type of the Tag property.
+	/// </summary>
+	public class TagTypeCompatibility : ICompatibilityStrategy {
+		/// <summary>
+		/// Determine if two node item connectors could be connected to each other.
+		/// </summary>
+		/// <param name="from">From which node connector are we connecting.</param>
+		/// <param name="to">To which node connector are we connecting?</param>
+		/// <returns><see langword="true"/> if the connection is valid; <see langword="false"/> otherwise</returns>
+		public bool CanConnect( NodeConnector @from, NodeConnector to ) 
+		{
+			if (null == @from.Item.Tag || null == to.Item.Tag) return false;
+			if (@from.Item.Tag.GetType() == @to.Item.Tag.GetType())
+			{
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/Graph/Graph.csproj
+++ b/Graph/Graph.csproj
@@ -42,6 +42,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compatibility\AlwaysCompatible.cs" />
+    <Compile Include="Compatibility\NeverCompatible.cs" />
+    <Compile Include="Compatibility\ICompatibilityStrategy.cs" />
+    <Compile Include="Compatibility\TagTypeCompatibility.cs" />
     <Compile Include="Items\NodeNumericSliderItem.cs" />
     <Compile Include="NodeSelection.cs" />
     <Compile Include="Items\NodeDropDownItem.cs" />

--- a/Graph/GraphRenderer.cs
+++ b/Graph/GraphRenderer.cs
@@ -87,6 +87,18 @@ namespace Graph
 			if (state == RenderState.None)
 			{
 				graphics.DrawEllipse(Pens.Black, bounds);
+			} else if ((state & RenderState.Highlight) != 0) 
+			{
+				// First draw the normal black border
+				graphics.DrawEllipse(Pens.Black, bounds);
+
+				// Draw an additional highlight around the connector
+				RectangleF highlightBounds = new RectangleF(bounds.X,bounds.Y,bounds.Width,bounds.Height);
+				highlightBounds.Width += 10;
+				highlightBounds.Height += 10;
+				highlightBounds.X -= 5;
+				highlightBounds.Y -= 5;
+				graphics.DrawEllipse(Pens.OrangeRed, highlightBounds);
 			} else
 			{
 				graphics.DrawArc(Pens.Black, bounds, 90, 180);
@@ -95,6 +107,8 @@ namespace Graph
 					graphics.DrawArc(pen, bounds, 270, 180);
 				}
 			}
+
+			
 		}
 
 		static void RenderArrow(Graphics graphics, RectangleF bounds, RenderState connectionState)
@@ -315,10 +329,17 @@ namespace Graph
 									connected = true;
 								}
 							}
+
+							// Apply highlight flag as needed
+							RenderState renderState = inputConnector.state;
+							if( inputConnector.Highlight ) 
+							{
+								renderState |= RenderState.Highlight;
+							}
 							
 							RenderConnector(graphics, 
 											inputConnector.bounds, 
-											inputConnector.state);
+											renderState);
 
 							if (connected)
 								RenderArrow(graphics, inputConnector.bounds, state);
@@ -334,6 +355,11 @@ namespace Graph
 							{
 								if (connection.From == outputConnector)
 									state |= connection.state | RenderState.Connected;
+							}
+							// Apply highlight flag as needed
+							if( outputConnector.Highlight ) 
+							{
+								state |= RenderState.Highlight;
 							}
 							RenderConnector(graphics, outputConnector.bounds, state);
 						}

--- a/Graph/NodeConnector.cs
+++ b/Graph/NodeConnector.cs
@@ -34,6 +34,7 @@ namespace Graph
 		public Node				Node		{ get { return Item.Node; } }
 		public NodeItem			Item		{ get; private set; }
 		public bool				Enabled		{ get; internal set; }
+		public bool				Highlight	{ get; internal set; }
 
 		internal PointF			Center		{ get { return new PointF((bounds.Left + bounds.Right) / 2.0f, (bounds.Top + bounds.Bottom) / 2.0f); } }
 		internal RectangleF		bounds;

--- a/Graph/RenderState.cs
+++ b/Graph/RenderState.cs
@@ -36,6 +36,7 @@ namespace Graph
 		DraggedOver	= 4,
 		Dragging	= 8,
 		Focus		= 16,
-		Forbidden	= 32
+		Forbidden	= 32,
+		Highlight	= 64
 	}
 }

--- a/GraphExample/ExampleForm.Designer.cs
+++ b/GraphExample/ExampleForm.Designer.cs
@@ -28,27 +28,13 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.graphControl = new Graph.GraphControl();
 			this.label1 = new System.Windows.Forms.Label();
 			this.showLabelsCheckBox = new System.Windows.Forms.CheckBox();
 			this.label2 = new System.Windows.Forms.Label();
 			this.label3 = new System.Windows.Forms.Label();
 			this.label4 = new System.Windows.Forms.Label();
+			this.graphControl = new Graph.GraphControl();
 			this.SuspendLayout();
-			// 
-			// graphControl
-			// 
-			this.graphControl.AllowDrop = true;
-			this.graphControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.graphControl.BackColor = System.Drawing.SystemColors.Window;
-			this.graphControl.Location = new System.Drawing.Point(108, 12);
-			this.graphControl.Name = "graphControl";
-			this.graphControl.ShowLabels = false;
-			this.graphControl.Size = new System.Drawing.Size(678, 378);
-			this.graphControl.TabIndex = 0;
-			this.graphControl.Text = "graphControl";
 			// 
 			// label1
 			// 
@@ -102,7 +88,23 @@
 			this.label4.Text = "color node";
 			this.label4.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ColorNode_MouseDown);
 			// 
-			// Form1
+			// graphControl
+			// 
+			this.graphControl.AllowDrop = true;
+			this.graphControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.graphControl.BackColor = System.Drawing.SystemColors.Window;
+			this.graphControl.FocusElement = null;
+			this.graphControl.HighlightCompatible = true;
+			this.graphControl.Location = new System.Drawing.Point(108, 12);
+			this.graphControl.Name = "graphControl";
+			this.graphControl.ShowLabels = false;
+			this.graphControl.Size = new System.Drawing.Size(678, 378);
+			this.graphControl.TabIndex = 0;
+			this.graphControl.Text = "graphControl";
+			// 
+			// ExampleForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -114,7 +116,7 @@
 			this.Controls.Add(this.label1);
 			this.Controls.Add(this.graphControl);
 			this.DoubleBuffered = true;
-			this.Name = "Form1";
+			this.Name = "ExampleForm";
 			this.Text = "Form1";
 			this.ResumeLayout(false);
 			this.PerformLayout();

--- a/GraphExample/ExampleForm.cs
+++ b/GraphExample/ExampleForm.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Windows.Forms;
 using Graph;
 using System.Drawing.Drawing2D;
+using Graph.Compatibility;
 using Graph.Items;
 
 namespace GraphNodes
@@ -18,11 +19,13 @@ namespace GraphNodes
 		{
 			InitializeComponent();
 
+			graphControl.CompatibilityStrategy = new TagTypeCompatibility();
+
 			var someNode = new Node("My Title");
 			someNode.Location = new Point(500, 100);
-			var check1Item = new NodeCheckboxItem("Check 1", true, false);
+			var check1Item = new NodeCheckboxItem("Check 1", true, false) { Tag = 31337 };
 			someNode.AddItem(check1Item);
-			someNode.AddItem(new NodeCheckboxItem("Check 2", true, false));
+			someNode.AddItem(new NodeCheckboxItem("Check 2", true, false) { Tag = 42f });
 			
 			graphControl.AddNode(someNode);
 
@@ -31,7 +34,7 @@ namespace GraphNodes
 			var redChannel		= new NodeSliderItem("R", 64.0f, 16.0f, 0, 1.0f, 0.0f, false, false);
 			var greenChannel	= new NodeSliderItem("G", 64.0f, 16.0f, 0, 1.0f, 0.0f, false, false);
 			var blueChannel		= new NodeSliderItem("B", 64.0f, 16.0f, 0, 1.0f, 0.0f, false, false);
-			var colorItem		= new NodeColorItem("Color", Color.Black, false, true);
+			var colorItem		= new NodeColorItem("Color", Color.Black, false, true) { Tag = 1337 };
 
 			EventHandler<NodeItemEventArgs> channelChangedDelegate = delegate(object sender, NodeItemEventArgs args)
 			{
@@ -55,7 +58,7 @@ namespace GraphNodes
 
 			var textureNode = new Node("Texture");
 			textureNode.Location = new Point(300, 150);
-			var imageItem = new NodeImageItem(Properties.Resources.example, 64, 64, false, true);
+			var imageItem = new NodeImageItem(Properties.Resources.example, 64, 64, false, true) { Tag = 1000f };
 			imageItem.Clicked += new EventHandler<NodeItemEventArgs>(OnImgClicked);
 			textureNode.AddItem(imageItem);
 			graphControl.AddNode(textureNode);


### PR DESCRIPTION
This is something I have been experimenting with. I wanted to be able to give visual feedback to indicate if a certain node item input is compatible with another output (or vice versa).

This is achieved by supplying an instance of an `ICompatibilityStrategy` to the graph control. This should allow for a high amount of customizability.
One example strategy I supplied it the `TagTypeCompatibility` strategy, which simply compares the type of the `Tag` property that is assigned to a node item. I also adjusted the example application to showcase how this works.

I left this behavior disabled by default.
